### PR TITLE
add artifact generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,36 @@ jobs:
         run: npm install
       - name: test
         run: npm test
+
+  build-web-artifact:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: dependencies
+        run: npm install
+      - name: build
+        run: npm run build
+      - name: Attest
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: '${{ github.workspace }}/dist'
+      - name: Archive production artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: web-artifact
+          path: build
+
   build-docker-image:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,18 +46,15 @@ jobs:
         run: npm install
       - name: build
         run: npm run build
-      - name: Create release artifact
-        run: |
-          tar -czvf release.tar.gz dist
       - name: Attest
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: '${{ github.workspace }}/release.tar.gz'
+          subject-path: '${{ github.workspace }}/dist'
       - name: Archive production artifact
         uses: actions/upload-artifact@v4
         with:
           name: web-artifact
-          path: '${{ github.workspace }}/release.tar.gz'
+          path: '${{ github.workspace }}/dist'
 
   build-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           subject-path: '${{ github.workspace }}/release.tar.gz'
       - name: Archive production artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: web-artifact
           path: '${{ github.workspace }}/release.tar.gz'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,15 +46,18 @@ jobs:
         run: npm install
       - name: build
         run: npm run build
+      - name: Create release artifact
+        run: |
+          tar -czvf release.tar.gz dist
       - name: Attest
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: '${{ github.workspace }}/dist'
+          subject-path: '${{ github.workspace }}/release.tar.gz'
       - name: Archive production artifact
         uses: actions/upload-artifact@v2
         with:
           name: web-artifact
-          path: build
+          path: '${{ github.workspace }}/release.tar.gz'
 
   build-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           subject-path: '${{ github.workspace }}/release.tar.gz'
       - name: Archive production artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: web-artifact
           path: '${{ github.workspace }}/release.tar.gz'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,10 @@ jobs:
         with:
           subject-path: '${{ github.workspace }}/dist'
       - name: Archive production artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: web-artifact
-          path: build
+          path: dist
 
   build-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,18 @@ jobs:
         run: npm install
       - name: build
         run: npm run build
+      - name: Create release artifact
+        run: |
+          tar -czvf release.tar.gz dist
       - name: Attest
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: '${{ github.workspace }}/dist'
+          subject-path: '${{ github.workspace }}/release.tar.gz'
       - name: Archive production artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v2
         with:
           name: web-artifact
-          path: dist
+          path: '${{ github.workspace }}/release.tar.gz'
 
   build-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,18 +50,15 @@ jobs:
         run: npm install
       - name: build
         run: npm run build
-      - name: Create release artifact
-        run: |
-          tar -czvf release.tar.gz dist
       - name: Attest
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: '${{ github.workspace }}/release.tar.gz'
+          subject-path: '${{ github.workspace }}/dist'
       - name: Archive production artifact
         uses: actions/upload-artifact@v4
         with:
           name: web-artifact
-          path: '${{ github.workspace }}/release.tar.gz'
+          path: '${{ github.workspace }}/dist'
 
   build-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,36 @@ jobs:
         run: npm install
       - name: test
         run: npm test
+
+  build-web-artifact:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: dependencies
+        run: npm install
+      - name: build
+        run: npm run build
+      - name: Attest
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: '${{ github.workspace }}/dist'
+      - name: Archive production artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: web-artifact
+          path: build
+
   build-docker-image:
     runs-on: ubuntu-latest
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,18 @@
       "license": "ISC",
       "dependencies": {
         "express": "^4.19.2"
+      },
+      "devDependencies": {
+        "@vercel/ncc": "^0.38.1"
+      }
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+      "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
+      "dev": true,
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
       }
     },
     "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,15 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "echo \"Error: no test specified\" && exit 0",
+    "build": "ncc build index.js --license licenses.txt"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@vercel/ncc": "^0.38.1"
   }
 }


### PR DESCRIPTION
This pull request introduces significant updates to the project's continuous integration (CI) pipeline and build process. The most important changes include the addition of a new job in the GitHub Actions workflow for building a web artifact and the introduction of a new build script in the `package.json` file.

Addition of new CI job:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR33-R62): A new job named `build-web-artifact` has been added to the GitHub Actions workflow. This job checks out the repository, sets up Node.js, installs dependencies, runs a build script, attests the build, and archives the production artifact. This job runs on the latest version of Ubuntu and has specific permissions set for reading contents, writing packages, writing ID tokens, and writing attestations.

Changes to build process:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R16): A new build script has been added to the `scripts` section. This script uses the `ncc` package to build the `index.js` file and includes a license file. Additionally, the `ncc` package has been added to the `devDependencies` section.