### PR TITLE
Add arm64 for images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,9 @@ jobs:
         run: |
           echo Building with version ${{ steps.output-collector.outputs.output }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -100,6 +103,9 @@ jobs:
         with:
           push: true
           labels: ${{ steps.meta-docker.outputs.labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64
           build-args: |
             RUNNER_VERSION=${{ steps.output-collector.outputs.output }}
           tags: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
         run: |
           echo Building with version ${{ steps.output-collector.outputs.output }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -105,6 +108,9 @@ jobs:
         with:
           push: false
           labels: ${{ steps.meta-docker.outputs.labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64
           build-args: |
             RUNNER_VERSION=${{ steps.output-collector.outputs.output }}
           tags: |


### PR DESCRIPTION
Enhancements to build and CI processes:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R81-R83): Added a step to set up QEMU using `docker/setup-qemu-action@v3` and specified `linux/amd64` and `linux/arm64` as target platforms for Docker builds. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R81-R83) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R106-R108)
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR86-R88): Added a step to set up QEMU using `docker/setup-qemu-action@v3` and specified `linux/amd64` and `linux/arm64` as target platforms for Docker builds. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR86-R88) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR111-R113)